### PR TITLE
fix: group CodeQL actions to avoid failing CIs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  
+    groups:
+      # init/autobuild/analyze must stay on the same version or CodeQL errors out
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
+
   # Root Go module
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
This PR fixes the issue of having many CodeQL actions bumped in different PRs by dependabot (they need to be updated at once to properly work).